### PR TITLE
Allow for Admins only to create reactions

### DIFF
--- a/src/components/posts/Posts.css
+++ b/src/components/posts/Posts.css
@@ -79,3 +79,7 @@
 .posticon {
     margin: 0 0 0 .50rem;
 }
+
+.cursor__pointer {
+    cursor: pointer;
+}

--- a/src/components/reactions/ReactionForm.js
+++ b/src/components/reactions/ReactionForm.js
@@ -1,0 +1,68 @@
+import React, { useContext, useState } from "react"
+import { ReactionContext } from "./ReactionProvider"
+
+export const ReactionForm = (props) => {
+    // Use props
+    const { setIsReactionFormVisible, getReactions } = props;
+
+    // Use required contexts
+    const { createReaction } = useContext(ReactionContext)
+
+    // Component State
+    const [newReaction, setNewReaction] = useState({})
+
+    // Component functions
+    const handleControlledInputChange = (event) => {
+        const tempReaction = Object.assign({}, newReaction)
+        tempReaction[event.target.name] = event.target.value
+        setNewReaction(tempReaction)
+    }
+
+    const submitReaction = () => {
+        createReaction(newReaction)
+            .then(getReactions())
+    }
+
+    return (
+        <div>
+            <form>
+                <fieldset>
+                    <div className="form-group">
+                        <input
+                            type="text"
+                            name="label"
+                            required
+                            autoFocus
+                            className="form-control form-control-sm w-75 mx-auto mt-2"
+                            placeholder="Reaction Label"
+                            onChange={handleControlledInputChange}
+                        />
+                    </div>
+                </fieldset>
+                <fieldset>
+                    <div className="form-group">
+                        <input
+                            type="text"
+                            name="image_url"
+                            required
+                            className="form-control form-control-sm w-75 mx-auto mt-2"
+                            placeholder="Reaction Image URL"
+                            onChange={handleControlledInputChange}
+                        />
+                    </div>
+                </fieldset>
+                <button
+                    type="submit"
+                    className="btn btn-primary btn-sm"
+                    onClick={e => {
+                        e.preventDefault()
+                        submitReaction()
+                        setIsReactionFormVisible(prev => !prev)
+                    }}
+                >
+                    Create Reaction
+                </button>
+            </form>
+        </div>
+    )
+}

--- a/src/components/reactions/ReactionProvider.js
+++ b/src/components/reactions/ReactionProvider.js
@@ -5,6 +5,18 @@ export const ReactionContext = React.createContext()
 export const ReactionProvider = (props) => {
     const [reactionsList, setReactionsList] = useState([])
 
+    const createReaction = (reactionDetails) => {
+        return fetch("http://localhost:8000/reactions", {
+            method: "POST",
+            headers: {
+                "Authorization": `Token ${localStorage.getItem("rare_user_id")}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(reactionDetails)
+        })
+            .then(res => res.json())
+    }
+
     const getReactions = () => {
         return fetch("http://localhost:8000/reactions", {
             headers: {
@@ -40,7 +52,7 @@ export const ReactionProvider = (props) => {
 
     return (
         <ReactionContext.Provider value={{
-            reactionsList, getReactions, createPostReaction, deletePostReaction
+            reactionsList, getReactions, createPostReaction, deletePostReaction, createReaction
         }}>
             {props.children}
         </ReactionContext.Provider>

--- a/src/components/reactions/ReactionSelector.js
+++ b/src/components/reactions/ReactionSelector.js
@@ -1,11 +1,16 @@
-import React, { useContext } from 'react'
+import React, { useContext, useState } from 'react'
 import { useParams } from 'react-router-dom'
+import { AuthContext } from '../auth/AuthProvider'
 import { ReactionContext } from "./ReactionProvider"
+import { ReactionForm } from "./ReactionForm"
 
 export const ReactionSelector = (props) => {
     const params = useParams()
     const { createPostReaction, deletePostReaction } = useContext(ReactionContext)
+    const { isAdmin } = useContext(AuthContext);
     const { reactionsList, currentUserPostReactions, setCurrentUserPostReactions, getReactions, getReactionCounts, getPostById, setPost } = props;
+
+    const [isReactionFormVisible, setIsReactionFormVisible] = useState(false)
 
     const handleUpdateCurrentUserPostReactions = (reactionId) => {
         const updatedPostReactions = currentUserPostReactions
@@ -40,6 +45,20 @@ export const ReactionSelector = (props) => {
                     <span>{reaction.label}</span>
                 </div>
             ))}
+            {isAdmin ? (
+                <>
+                    <div
+                        className="underline text-primary cursor__pointer"
+                        onClick={() => { setIsReactionFormVisible(prev => !prev) }}
+                    ><u>Create New Reaction</u></div>
+                    {isReactionFormVisible ? (
+                        <ReactionForm
+                            setIsReactionFormVisible={setIsReactionFormVisible}
+                            getReactions={getReactions}
+                        />
+                    ) : ('')}
+                </>
+            ) : ('')}
         </div>
     )
 }


### PR DESCRIPTION
**NOTE**: Requires the API functionality from API PR 92!!!

* Only show the 'Create Reaction' option if the user is an admin.
* Provides a form to create the reaction
* Updates the reaction list in real-time as reactions are added